### PR TITLE
デフォルトで GPT-4 モデルをデプロイ

### DIFF
--- a/5.internal-document-search/README.md
+++ b/5.internal-document-search/README.md
@@ -142,21 +142,6 @@ azd env new AnotherEnvName
 azd up --environment AnotherEnvName
 ```
 
-### GPT-4モデルの利用
-2023年6月現在、GPT-4 モデルは申請することで利用可能な状態です。このサンプルは GPT-4 モデルのデプロイに対応していますが、GPT-4 モデルを利用する場合には、[こちら](https://learn.microsoft.com/ja-jp/azure/cognitive-services/openai/how-to/create-resource?pivots=web-portal#deploy-a-model)を参考に、GPT-4 モデルをデプロイしてください。また、GPT-4 モデルの利用申請は[こちらのフォーム](https://aka.ms/oai/get-gpt4)から可能です。
-
-GPT-4 モデルのデプロイ後、以下の操作を実行してください。
-
-1. このサンプルをデプロイした際に、プロジェクトのディレクトリに `./${環境名}/.env` ファイルが作成されています。このファイルを任意のエディタで開きます。
-1. 以下の行を探して、デプロイした GPT-4 モデルのデプロイ名を指定してください。
-```
-AZURE_OPENAI_GPT_4_DEPLOYMENT="" # GPT-4モデルのデプロイ名
-AZURE_OPENAI_GPT_4_32K_DEPLOYMENT="" # GPT-4-32Kモデルのデプロイ名
-```
-1. `azd up` を実行します。
-
-GPT-4 モデルは、チャット機能、文書検索機能のオプションで利用することができます。
-
 ### Easy Authの設定（オプション）
 必要に応じて、Azure AD に対応した Easy Auth を設定します。Easy Auth を設定した場合、UI の右上にログインユーザのアカウント名が表示され、チャットの履歴ログにもアカウント名が記録されます。
 Easy Auth の設定は、[こちら](https://learn.microsoft.com/ja-jp/azure/app-service/scenario-secure-app-authentication-app-service)を参考にしてください。

--- a/5.internal-document-search/infra/main.bicep
+++ b/5.internal-document-search/infra/main.bicep
@@ -41,8 +41,8 @@ param openAiSkuName string = 'S0'
 
 param openAiGpt35TurboDeploymentName string = 'gpt-35-turbo-deploy'
 param openAiGpt35Turbo16kDeploymentName string = 'gpt-35-turbo-16k-deploy'
-param openAiGpt4DeploymentName string = ''
-param openAiGpt432kDeploymentName string = ''
+param openAiGpt4DeploymentName string = 'gpt-4-deploy'
+param openAiGpt432kDeploymentName string = 'gpt-4-32k-deploy'
 param openAiApiVersion string = '2023-05-15'
 
 
@@ -170,8 +170,8 @@ module backend 'core/host/appservice.bicep' = {
       AZURE_SEARCH_SERVICE: searchService.outputs.name
       AZURE_OPENAI_GPT_35_TURBO_DEPLOYMENT: openAiGpt35TurboDeploymentName
       AZURE_OPENAI_GPT_35_TURBO_16K_DEPLOYMENT: openAiGpt35Turbo16kDeploymentName
-      AZURE_OPENAI_GPT_4_DEPLOYMENT: ''
-      AZURE_OPENAI_GPT_4_32K_DEPLOYMENT: ''
+      AZURE_OPENAI_GPT_4_DEPLOYMENT: openAiGpt4DeploymentName
+      AZURE_OPENAI_GPT_4_32k_DEPLOYMENT: openAiGpt432kDeploymentName
       AZURE_OPENAI_API_VERSION: '2023-05-15'
       AZURE_COSMOSDB_CONTAINER: cosmosDbContainerName
       AZURE_COSMOSDB_DATABASE: cosmosDbDatabaseName
@@ -200,7 +200,7 @@ module openAi 'core/ai/cognitiveservices.bicep' = {
         }
         sku: {
           name: 'Standard'
-          capacity: 120
+          capacity: 30
         }
       }
       {
@@ -212,7 +212,31 @@ module openAi 'core/ai/cognitiveservices.bicep' = {
         }
         sku: {
           name: 'Standard'
-          capacity: 120
+          capacity: 30
+        }
+      }
+      {
+        name: openAiGpt4DeploymentName
+        model: {
+          format: 'OpenAI'
+          name: 'gpt-4'
+          version: '0613'
+        }
+        sku: {
+          name: 'Standard'
+          capacity: 30
+        }
+      }
+      {
+        name: openAiGpt432kDeploymentName
+        model: {
+          format: 'OpenAI'
+          name: 'gpt-4-32k'
+          version: '0613'
+        }
+        sku: {
+          name: 'Standard'
+          capacity: 30
         }
       }
     ]
@@ -629,7 +653,7 @@ output AZURE_OPENAI_RESOURCE_GROUP string = openAiResourceGroup.name
 output AZURE_OPENAI_GPT_35_TURBO_DEPLOYMENT string = openAiGpt35TurboDeploymentName
 output AZURE_OPENAI_GPT_35_TURBO_16K_DEPLOYMENT string = openAiGpt35Turbo16kDeploymentName
 output AZURE_OPENAI_GPT_4_DEPLOYMENT string = openAiGpt4DeploymentName
-output AZURE_OPENAI_GPT_4_32K_DEPLOYMENT string = openAiGpt432kDeploymentName
+output AZURE_OPENAI_GPT_4_32k_DEPLOYMENT string = openAiGpt432kDeploymentName
 output AZURE_OPENAI_API_VERSION string = openAiApiVersion
 
 output AZURE_FORMRECOGNIZER_SERVICE string = formRecognizer.outputs.name

--- a/5.internal-document-search/infra/main.bicep
+++ b/5.internal-document-search/infra/main.bicep
@@ -171,7 +171,7 @@ module backend 'core/host/appservice.bicep' = {
       AZURE_OPENAI_GPT_35_TURBO_DEPLOYMENT: openAiGpt35TurboDeploymentName
       AZURE_OPENAI_GPT_35_TURBO_16K_DEPLOYMENT: openAiGpt35Turbo16kDeploymentName
       AZURE_OPENAI_GPT_4_DEPLOYMENT: openAiGpt4DeploymentName
-      AZURE_OPENAI_GPT_4_32k_DEPLOYMENT: openAiGpt432kDeploymentName
+      AZURE_OPENAI_GPT_4_32K_DEPLOYMENT: openAiGpt432kDeploymentName
       AZURE_OPENAI_API_VERSION: '2023-05-15'
       AZURE_COSMOSDB_CONTAINER: cosmosDbContainerName
       AZURE_COSMOSDB_DATABASE: cosmosDbDatabaseName
@@ -200,7 +200,7 @@ module openAi 'core/ai/cognitiveservices.bicep' = {
         }
         sku: {
           name: 'Standard'
-          capacity: 30
+          capacity: 120
         }
       }
       {
@@ -212,7 +212,7 @@ module openAi 'core/ai/cognitiveservices.bicep' = {
         }
         sku: {
           name: 'Standard'
-          capacity: 30
+          capacity: 120
         }
       }
       {
@@ -224,7 +224,7 @@ module openAi 'core/ai/cognitiveservices.bicep' = {
         }
         sku: {
           name: 'Standard'
-          capacity: 30
+          capacity: 120
         }
       }
       {
@@ -236,7 +236,7 @@ module openAi 'core/ai/cognitiveservices.bicep' = {
         }
         sku: {
           name: 'Standard'
-          capacity: 30
+          capacity: 120
         }
       }
     ]
@@ -653,7 +653,7 @@ output AZURE_OPENAI_RESOURCE_GROUP string = openAiResourceGroup.name
 output AZURE_OPENAI_GPT_35_TURBO_DEPLOYMENT string = openAiGpt35TurboDeploymentName
 output AZURE_OPENAI_GPT_35_TURBO_16K_DEPLOYMENT string = openAiGpt35Turbo16kDeploymentName
 output AZURE_OPENAI_GPT_4_DEPLOYMENT string = openAiGpt4DeploymentName
-output AZURE_OPENAI_GPT_4_32k_DEPLOYMENT string = openAiGpt432kDeploymentName
+output AZURE_OPENAI_GPT_4_32K_DEPLOYMENT string = openAiGpt432kDeploymentName
 output AZURE_OPENAI_API_VERSION string = openAiApiVersion
 
 output AZURE_FORMRECOGNIZER_SERVICE string = formRecognizer.outputs.name


### PR DESCRIPTION
内容
- bicep による Azure リソースの作成時、デフォルトで GPT-4 モデルをデプロイするように変更

背景
- 本リファレンスアーキテクチャのアプリケーションが開発されたときは、GPT-4 は Preview 段階であり、GPT-4 の利用には申請が必要であった
- そのため、GPT-4 はデフォルトでデプロイせず、デプロイをしたユーザーが必要な手続き (複数の bicep ファイルに) をする仕様としていた
- その後、GPT-4 は GA されて全てのユーザーが利用できるようになったため、GPT-4 モデルをデフォルトでデプロイされる仕様に変更

テスト
- GPT-4 の利用確認テスト (社内文書検索)
![image](https://github.com/yus04/jp-azureopenai-samples/assets/49590084/6df3d03e-99e5-40e5-8e55-fbdf2e168fc1)

- GPT-4 の利用確認テスト (企業内向け Chat)
![image](https://github.com/yus04/jp-azureopenai-samples/assets/49590084/50ce23fb-2e67-4f9f-8af4-c70edcedfdb1)

- GPT-4-32k の利用確認テスト (社内文書検索)
![image](https://github.com/yus04/jp-azureopenai-samples/assets/49590084/764c1139-34ff-4723-8480-6d060c864391)

- GPT-4-32k の利用確認テスト (企業内向け Chat)
![image](https://github.com/yus04/jp-azureopenai-samples/assets/49590084/db451b42-2a78-497c-855d-aec26958cc93)