### PR TITLE
GPT モデルのデプロイリージョンの選択

### DIFF
--- a/5.internal-document-search/infra/core/ai/cognitiveservices.bicep
+++ b/5.internal-document-search/infra/core/ai/cognitiveservices.bicep
@@ -3,13 +3,80 @@ param location string = resourceGroup().location
 param tags object = {}
 
 param customSubDomainName string = name
-param deployments array = []
 param kind string = 'OpenAI'
 @allowed(['Enabled', 'Disabled'])
 param publicNetworkAccess string = 'Enabled'
 param sku object = {
   name: 'S0'
 }
+
+param useOpenAiGpt4 bool = true
+param openAiGpt35TurboDeploymentName string = ''
+param openAiGpt35Turbo16kDeploymentName string = ''
+param openAiGpt4DeploymentName string = ''
+param openAiGpt432kDeploymentName string = ''
+
+param openAiGpt35TurboDeployObj object = {
+  name: openAiGpt35TurboDeploymentName
+  model: {
+    format: 'OpenAI'
+    name: 'gpt-35-turbo'
+    version: '0613'
+  }
+  sku: {
+    name: 'Standard'
+    capacity: 120
+  }
+}
+
+param openAiGpt35Turbo16kDeployObj object = {
+  name: openAiGpt35Turbo16kDeploymentName
+  model: {
+    format: 'OpenAI'
+    name: 'gpt-35-turbo-16k'
+    version: '0613'
+  }
+  sku: {
+    name: 'Standard'
+    capacity: 120
+  }
+}
+
+param openAiGpt4DeployObj object = {
+  name: openAiGpt4DeploymentName
+  model: {
+    format: 'OpenAI'
+    name: 'gpt-4'
+    version: '0613'
+  }
+  sku: {
+    name: 'Standard'
+    capacity: 40
+  }
+}
+
+param openAiGpt432kDeployObj object = {
+  name: openAiGpt432kDeploymentName
+  model: {
+    format: 'OpenAI'
+    name: 'gpt-4-32k'
+    version: '0613'
+  }
+  sku: {
+    name: 'Standard'
+    capacity: 40
+  }
+}
+
+param deployments array = useOpenAiGpt4? [
+  openAiGpt35TurboDeployObj
+  openAiGpt35Turbo16kDeployObj
+  openAiGpt4DeployObj
+  openAiGpt432kDeployObj
+]: [
+  openAiGpt35TurboDeployObj
+  openAiGpt35Turbo16kDeployObj
+]
 
 resource account 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
   name: name

--- a/5.internal-document-search/infra/main.bicep
+++ b/5.internal-document-search/infra/main.bicep
@@ -35,8 +35,14 @@ param storageContainerName string = 'content'
 
 param openAiServiceName string = ''
 param openAiResourceGroupName string = ''
-param openAiResourceGroupLocation string = location
 
+@allowed([
+  'australiaeast'
+  'canadaeast'
+  'swedencentral'
+  'switzerlandnorth'
+])
+param openAiResourceGroupLocation string
 param openAiSkuName string = 'S0'
 
 param openAiGpt35TurboDeploymentName string = 'gpt-35-turbo-deploy'
@@ -251,7 +257,7 @@ module openAi 'core/ai/cognitiveservices.bicep' = {
         }
         sku: {
           name: 'Standard'
-          capacity: 120
+          capacity: 40
         }
       }
       {
@@ -263,7 +269,7 @@ module openAi 'core/ai/cognitiveservices.bicep' = {
         }
         sku: {
           name: 'Standard'
-          capacity: 120
+          capacity: 40
         }
       }
     ]
@@ -736,6 +742,7 @@ output AZURE_OPENAI_GPT_35_TURBO_16K_DEPLOYMENT string = openAiGpt35Turbo16kDepl
 output AZURE_OPENAI_GPT_4_DEPLOYMENT string = openAiGpt4DeploymentName
 output AZURE_OPENAI_GPT_4_32K_DEPLOYMENT string = openAiGpt432kDeploymentName
 output AZURE_OPENAI_API_VERSION string = openAiApiVersion
+output AZURE_OPENAI_RESOURCE_GROUP_LOCATION string = openAiResourceGroupLocation
 
 output AZURE_FORMRECOGNIZER_SERVICE string = formRecognizer.outputs.name
 output AZURE_FORMRECOGNIZER_RESOURCE_GROUP string = formRecognizerResourceGroup.name

--- a/5.internal-document-search/infra/main.bicep
+++ b/5.internal-document-search/infra/main.bicep
@@ -37,20 +37,30 @@ param openAiServiceName string = ''
 param openAiResourceGroupName string = ''
 
 @allowed([
-  'australiaeast'
-  'canadaeast'
-  'swedencentral'
-  'switzerlandnorth'
+  '1.  australiaeast    (You can deploy GPT-4 and GPT-3 models)'
+  '2.  canadaeast       (You can deploy GPT-4 and GPT-3 models)'
+  '3.  swedencentral    (You can deploy GPT-4 and GPT-3 models)'
+  '4.  switzerlandnorth (You can deploy GPT-4 and GPT-3 models)'
+  '5.  eastus           (You can deploy only GPT-3 models)'
+  '6.  eastus2          (You can deploy only GPT-3 models)'
+  '7.  francecentral    (You can deploy only GPT-3 models)'
+  '8.  japaneast        (You can deploy only GPT-3 models)'
+  '9.  northcentralus   (You can deploy only GPT-3 models)'
+  '10. uksouth          (You can deploy only GPT-3 models)'
 ])
-param openAiResourceGroupLocation string
-param openAiSkuName string = 'S0'
+param AzureOpenAIServiceRegion string
 
+param delimiters array = ['.', '(']
+param aoaiRegionWithBlankSpace string = split(AzureOpenAIServiceRegion, delimiters)[1]
+param openAiResourceGroupLocation string = trim(aoaiRegionWithBlankSpace)
+param useOpenAiGpt4 bool = contains(AzureOpenAIServiceRegion, 'GPT-4')
+
+param openAiSkuName string = 'S0'
 param openAiGpt35TurboDeploymentName string = 'gpt-35-turbo-deploy'
 param openAiGpt35Turbo16kDeploymentName string = 'gpt-35-turbo-16k-deploy'
 param openAiGpt4DeploymentName string = 'gpt-4-deploy'
 param openAiGpt432kDeploymentName string = 'gpt-4-32k-deploy'
 param openAiApiVersion string = '2023-05-15'
-
 
 param formRecognizerServiceName string = ''
 param formRecognizerResourceGroupName string = ''
@@ -223,56 +233,11 @@ module openAi 'core/ai/cognitiveservices.bicep' = {
     sku: {
       name: openAiSkuName
     }
-    deployments: [
-      {
-        name: openAiGpt35TurboDeploymentName
-        model: {
-          format: 'OpenAI'
-          name: 'gpt-35-turbo'
-          version: '0613'
-        }
-        sku: {
-          name: 'Standard'
-          capacity: 120
-        }
-      }
-      {
-        name: openAiGpt35Turbo16kDeploymentName
-        model: {
-          format: 'OpenAI'
-          name: 'gpt-35-turbo-16k'
-          version: '0613'
-        }
-        sku: {
-          name: 'Standard'
-          capacity: 120
-        }
-      }
-      {
-        name: openAiGpt4DeploymentName
-        model: {
-          format: 'OpenAI'
-          name: 'gpt-4'
-          version: '0613'
-        }
-        sku: {
-          name: 'Standard'
-          capacity: 40
-        }
-      }
-      {
-        name: openAiGpt432kDeploymentName
-        model: {
-          format: 'OpenAI'
-          name: 'gpt-4-32k'
-          version: '0613'
-        }
-        sku: {
-          name: 'Standard'
-          capacity: 40
-        }
-      }
-    ]
+    useOpenAiGpt4: useOpenAiGpt4
+    openAiGpt35TurboDeploymentName: openAiGpt35TurboDeploymentName
+    openAiGpt35Turbo16kDeploymentName: openAiGpt35Turbo16kDeploymentName
+    openAiGpt4DeploymentName: openAiGpt4DeploymentName
+    openAiGpt432kDeploymentName: openAiGpt432kDeploymentName
     publicNetworkAccess: isPrivateNetworkEnabled ? 'Disabled' : 'Enabled'
   }
 }
@@ -288,6 +253,7 @@ module formRecognizer 'core/ai/cognitiveservices.bicep' = {
     sku: {
       name: formRecognizerSkuName
     }
+    deployments: []
   }
 }
 
@@ -743,6 +709,7 @@ output AZURE_OPENAI_GPT_4_DEPLOYMENT string = openAiGpt4DeploymentName
 output AZURE_OPENAI_GPT_4_32K_DEPLOYMENT string = openAiGpt432kDeploymentName
 output AZURE_OPENAI_API_VERSION string = openAiApiVersion
 output AZURE_OPENAI_RESOURCE_GROUP_LOCATION string = openAiResourceGroupLocation
+output USE_OPENAI_GPT4 bool = useOpenAiGpt4
 
 output AZURE_FORMRECOGNIZER_SERVICE string = formRecognizer.outputs.name
 output AZURE_FORMRECOGNIZER_RESOURCE_GROUP string = formRecognizerResourceGroup.name

--- a/5.internal-document-search/infra/main.parameters.json
+++ b/5.internal-document-search/infra/main.parameters.json
@@ -11,9 +11,6 @@
     "resourceGroupName": {
       "value": "${AZURE_RESOURCE_GROUP}"
     },
-    "openAiResourceGroupLocation": {
-      "value": "${AZURE_OPENAI_RESOURCE_GROUP_LOCATION}"
-    },
     "isPrivateNetworkEnabled": {
       "value": false
     },

--- a/5.internal-document-search/infra/main.parameters.json
+++ b/5.internal-document-search/infra/main.parameters.json
@@ -11,6 +11,9 @@
     "resourceGroupName": {
       "value": "${AZURE_RESOURCE_GROUP}"
     },
+    "openAiResourceGroupLocation": {
+      "value": "${AZURE_OPENAI_RESOURCE_GROUP_LOCATION}"
+    },
     "isPrivateNetworkEnabled": {
       "value": false
     },


### PR DESCRIPTION
内容
- https://github.com/yus04/jp-azureopenai-samples/pull/6 にあたり、GPT-4 モデルをデフォルトでデプロイ可能にしたものの、デプロイするリージョンによっては GPT-4 のデプロイができずにエラーになる問題を解消
- GPT-4 がデプロイできないリージョンを使いたい人のために、GPT-3 だけでもデプロイするできるリージョンを選択肢として追加

詳細
- GPT-4 と GPT-3 の両モデルでのデプロイ
  - https://learn.microsoft.com/ja-jp/azure/ai-services/openai/quotas-limits#regional-quota-limits によると、GPT-4, GPT-4-32k, GPT-3.5-Turbo が全てデプロイでき、最小 TPM が 32k を超えているリージョンは、australiaeast、canadaeast、swedencentral、switzerlandnorth の 4 つだったので、azd up 実行時にはこのリージョン内から選択式でデプロイするようにユーザーに選択させる仕様にした
  -<img width="638" alt="deploy-gpt3-gpt4" src="https://github.com/yus04/jp-azureopenai-samples/assets/49590084/ca719522-7680-42d0-aefa-55e36d8f23bb">

- GPT-3 のデプロイ
  - https://learn.microsoft.com/ja-jp/azure/ai-services/openai/concepts/models#gpt-35-turbo-model-availability によると、GPT-3.5-Turbo (0613) がデプロイできるリージョンが 10 箇所あるので、GPT-4 がデプロイできる上記 4 箇所を除いて、6 箇所のリージョンで GPT-3 のデプロイを選択式でできる仕様にした
  -<img width="635" alt="deploy-gpt3" src="https://github.com/yus04/jp-azureopenai-samples/assets/49590084/ef296690-c38f-4a41-b51b-32dad71d2227">


テスト
- GPT-4 と GPT-3 の両モデルでのデプロイ
  - GPT-3.5-Turbo, GPT-3.5-Turbo-16k, GPT-4, GPT-4-32k のモデルのデプロイ、呼び出しに成功したことを確認
  - <img width="1104" alt="image" src="https://github.com/yus04/jp-azureopenai-samples/assets/49590084/c5539a3f-ac20-4699-a996-4343b4028dd0">

- GPT-3 のデプロイ
  - GPT-3.5-Turbo, GPT-3.5-Turbo-16k にてデプロイ、呼び出しに成功したことを確認 (GPT-4, GPT-4-32k に関してはデプロイしていない)
  - ![image](https://github.com/yus04/jp-azureopenai-samples/assets/49590084/818114f9-e2ac-4b24-a048-96ed1a098dad)